### PR TITLE
chore(renovate): lift PR limits, track op & git-secrets via correct datasources

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,13 @@
     "github>aquaproj/aqua-renovate-config#2.9.0",
   ],
   dependencyDashboard: false,
+  // The Renovate workflow runs only weekly. With the default prHourlyLimit of
+  // 2, each run spends its whole budget on the most frequently-updating deps
+  // (the lazy plugin digests), so aqua tag updates were chronically starved and
+  // almost never reached a PR. Lift the hourly cap (weekly cadence makes a
+  // burst harmless) and raise the concurrent-open cap so the backlog can drain.
+  prHourlyLimit: 0,
+  prConcurrentLimit: 20,
   minimumReleaseAge: "10 days",
   osvVulnerabilityAlerts: true,
   vulnerabilityAlerts: {
@@ -20,6 +27,15 @@
       // a prebuilt darwin asset, so pin to v2.23.0 and ignore updates until
       // upstream resumes darwin releases.
       matchPackageNames: ["denisidoro/navi"],
+      enabled: false,
+    },
+    {
+      // aqua-renovate-config maps these to the github-releases datasource, but
+      // neither publishes GitHub Releases: 1password/cli ships via 1Password's
+      // own CDN, and awslabs/git-secrets is tag-only. The lookups return
+      // no-result on every run (noise in the logs) and can never produce an
+      // update, so disable them rather than let the failed lookups linger.
+      matchPackageNames: ["1password/cli", "awslabs/git-secrets"],
       enabled: false,
     },
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,12 +31,52 @@
     },
     {
       // aqua-renovate-config maps these to the github-releases datasource, but
-      // neither publishes GitHub Releases: 1password/cli ships via 1Password's
-      // own CDN, and awslabs/git-secrets is tag-only. The lookups return
-      // no-result on every run (noise in the logs) and can never produce an
-      // update, so disable them rather than let the failed lookups linger.
+      // neither publishes GitHub Releases (1password/cli ships via 1Password's
+      // own CDN, awslabs/git-secrets is tag-only), so that lookup always returns
+      // no-result. Disable only the mis-mapped datasource; the customManagers
+      // below re-track both via datasources that actually resolve.
+      matchDatasources: ["github-releases"],
       matchPackageNames: ["1password/cli", "awslabs/git-secrets"],
       enabled: false,
     },
+    {
+      // The 1Password product-history page exposes versions only inside the
+      // download-link hrefs (…/pkg/v2.34.1/op_darwin_arm64_v2.34.1.zip); pull
+      // the version out so semver comparison works. The pre-release suffix MUST
+      // be captured too (…-beta.03) — otherwise a beta build collapses to its
+      // bare X.Y.Z and masquerades as a stable release. With the suffix kept,
+      // Renovate's default ignoreUnstable drops the betas.
+      matchDatasources: ["custom.1password-cli"],
+      extractVersion: "v(?<version>\\d+\\.\\d+\\.\\d+(?:-[\\w.]+)?)",
+    },
   ],
+  // EXPERIMENTAL: 1password/cli and awslabs/git-secrets have no usable GitHub
+  // Releases, so aqua-renovate-config can't track them. Re-track each via the
+  // correct source. Verify on the next Renovate run before trusting these.
+  customManagers: [
+    {
+      // git-secrets publishes git tags (1.0.0 … 1.3.0) but no Releases.
+      customType: "regex",
+      managerFilePatterns: ["/(^|/)aqua\\.yaml$/"],
+      matchStrings: ["name:\\s*(?<depName>awslabs/git-secrets)@(?<currentValue>\\S+)"],
+      datasourceTemplate: "github-tags",
+    },
+    {
+      // 1password/cli has no public GitHub repo; aqua fetches it over HTTP and
+      // the canonical version list lives on the product-history page (scraped by
+      // the custom datasource below). Keep the literal `v` outside the capture
+      // so the bumped value stays `@vX.Y.Z`.
+      customType: "regex",
+      managerFilePatterns: ["/(^|/)aqua\\.yaml$/"],
+      matchStrings: ["name:\\s*(?<depName>1password/cli)@v(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      datasourceTemplate: "custom.1password-cli",
+      versioningTemplate: "semver",
+    },
+  ],
+  customDatasources: {
+    "1password-cli": {
+      defaultRegistryUrlTemplate: "https://app-updates.agilebits.com/product_history/CLI2",
+      format: "html",
+    },
+  },
 }


### PR DESCRIPTION
## Why

aqua's Renovate integration extracts every package but aqua tag updates almost never reached a PR (only `uv` #36 / `bun` #26 ever did). Two root causes from the 2026-06-18 run log:

1. **PR starvation** — weekly workflow + Renovate's default `prHourlyLimit: 2` means each run creates at most 2 PRs, both consumed by the frequently-changing lazy plugin digests. aqua tag updates never got a slot. Dependency dashboard disabled, so the backlog was invisible.
2. **Dead datasource lookups** — `1password/cli` and `awslabs/git-secrets` were mapped to `github-releases`, which neither publishes, so every run logged `no-result` and they could never update.

## Changes

**Limits**
- `prHourlyLimit: 0` + `prConcurrentLimit: 20` — weekly cadence makes an unbounded burst harmless; lets the backlog drain.

**op & git-secrets — re-tracked via working datasources (not just disabled)**
- `awslabs/git-secrets` → a customManager points it at `github-tags` (repo has tags `1.0.0..1.3.0`, no Releases).
- `1password/cli` → has **no public GitHub repo** (aqua fetches it over HTTP). A custom `html` datasource scrapes 1Password's product-history page; `extractVersion` pulls `X.Y.Z` from the download-link hrefs and keeps any `-beta.NN` suffix so `ignoreUnstable` filters pre-releases.
- The blanket `enabled:false` is narrowed to `matchDatasources: ["github-releases"]`, so only the mis-mapped lookup is suppressed while the new datasources stay live.

> ⚠️ **EXPERIMENTAL (op only):** the 1Password html scrape can't be dry-run locally. Confirm on the next Renovate run before trusting it — `workflow_dispatch` is available on `renovate.yml` for an on-demand check (optionally with `LOG_LEVEL=debug`). git-secrets (`github-tags`) and the limit changes are not experimental.

## Notes
- `aqua-checksums.json` is regenerated automatically by the existing `update-aqua-checksums.yml` workflow (`on: pull_request`) on any resulting aqua PR, so no manual checksum step is needed.

## Expected effect
Next run should open the aged-out aqua PRs that were stuck (all >10d): caddy `v2.11.4`, golangci-lint `v2.12.2`, kind `v0.32.0`, tree-sitter `v0.26.9`, zizmor `v1.25.2`, syft `v1.45.1`, grype `v0.114.0`, pinact `v4.1.0`, fzf CLI `v0.73.1`, bun `bun-v1.3.14`, circleci-cli, plus an op bump (currently `v2.33.1`, latest stable on the page) and the lazy backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)