### PR TITLE
chore(renovate): unblock op PRs by dropping its minimum release age

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -48,6 +48,14 @@
       // Renovate's default ignoreUnstable drops the betas.
       matchDatasources: ["custom.1password-cli"],
       extractVersion: "v(?<version>\\d+\\.\\d+\\.\\d+(?:-[\\w.]+)?)",
+      // The html datasource yields no releaseTimestamp, and current Renovate
+      // (minimumReleaseAgeBehaviour=timestamp-required) marks any update that
+      // lacks a timestamp as permanently "pending" when a global
+      // minimumReleaseAge is set — so without this override op updates resolve
+      // correctly but never open a PR. Drop the age gate for op only (0ms ->
+      // the `if (minimumReleaseAgeMs)` pending check is skipped); the PR is
+      // still human-reviewed and aqua re-verifies the SHA256 on install.
+      minimumReleaseAge: "0 days",
     },
   ],
   // EXPERIMENTAL: 1password/cli and awslabs/git-secrets have no usable GitHub


### PR DESCRIPTION
## Why

Follow-up to #44. I verified the op (`1password/cli`) tracking on a debug Renovate run (`workflow_dispatch`, run 27800292008):

- ✅ The custom `html` datasource **works** — it fetched the product-history page (387ms) and resolved an update: `newVersion: 2.34.1`, `updateType: minor`.
- ❌ …but **no PR is ever created**. Log: `Marking 2 release(s) as pending, as they do not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=timestamp-required`. The op update carried `pendingChecks: true`.

Root cause: the html datasource yields no `releaseTimestamp`. Current Renovate defaults `minimumReleaseAgeBehaviour` to `timestamp-required`, so with a global `minimumReleaseAge: "10 days"` any timestamp-less update is held as **pending** indefinitely (and the dependency dashboard is disabled, so it's invisible).

## Fix

Set `minimumReleaseAge: "0 days"` scoped to the `custom.1password-cli` datasource only. In `filter-checks.js` the pending gate is `if (minimumReleaseAgeMs)`, so `0ms` skips it and the PR is created. All other packages keep the 10-day gate (github-tags / github-releases carry timestamps).

**Trade-off:** op loses the 10-day stabilization gate — but it is unenforceable here anyway (no timestamps), op PRs are not auto-merged (human-reviewed), and aqua re-verifies the SHA256 on install. Acceptable.

## Verification after merge
Re-run `renovate.yml` (`workflow_dispatch`); a `renovate/1password-cli-2.x` PR bumping op should appear (no longer pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
