### PR TITLE
feat(skill): extend /review-renovate-pr to aqua.yaml tag PRs

### DIFF
--- a/.claude/skills/review-renovate-pr/SKILL.md
+++ b/.claude/skills/review-renovate-pr/SKILL.md
@@ -1,24 +1,30 @@
 ---
 name: review-renovate-pr
-description: Review open Renovate-generated PRs on this dotfiles repo that update vim plugins in lazy-lock.json. For each unreviewed PR, checks that the upstream commit is >= 10 days old, analyzes the upstream diff for supply-chain red flags (remote script exec, credential access, obfuscation, maintainer changes), posts a review comment automatically, then prints a chat summary with a merge recommendation per PR. When the tip SHA is too recent, falls back to reviewing the newest intermediate commit >=10d old and surfaces it as a hand-pin candidate (without editing files or closing PRs). Triggered by requests like "review the Renovate PRs", "check lazy plugin updates", "triage Renovate PRs", or explicit /review-renovate-pr invocation.
+description: Review open Renovate-generated PRs on this dotfiles repo. Covers two PR types — vim plugin pins in lazy-lock.json (digest/commit-pinned) and CLI tool versions in aqua.yaml (tag-pinned). For each unreviewed PR, checks that the upstream commit/tag is >= 10 days old, analyzes the upstream diff for supply-chain red flags (remote script exec, credential access, obfuscation, maintainer changes, compromised release pipelines), posts a review comment automatically, then prints a chat summary with a merge recommendation per PR. For lazy PRs whose tip SHA is too recent, falls back to reviewing the newest intermediate commit >=10d old and surfaces it as a hand-pin candidate. For aqua PRs, also flags when the PR lacks the regenerated aqua-checksums.json (needed for merge). Triggered by requests like "review the Renovate PRs", "check lazy plugin updates", "triage aqua updates", "triage Renovate PRs", or explicit /review-renovate-pr invocation.
 ---
 
 # review-renovate-pr
 
-Reviews Renovate-generated PRs that update vim plugin pins in `lazy-lock.json`. Posts a review comment on each PR and reports a summary to chat.
+Reviews Renovate-generated PRs that update **either** vim plugin pins in `lazy-lock.json` (digest/commit-pinned) **or** CLI tool versions in `aqua.yaml` (tag-pinned). Posts a review comment on each PR and reports a summary to chat.
 
 ## Scope
 
 - Only PRs in the current repo (`takaneko/dotfiles`)
 - Only PRs whose branch matches `renovate/*` (Renovate-generated)
-- Only unreviewed PRs: skip any PR that already has at least one issue comment OR a label starting with `reviewed`
+- Two reviewable PR types, distinguished by which file the diff touches:
+  - **lazy** — `lazy-lock.json` digest bumps (vim plugins)
+  - **aqua** — `aqua.yaml` tag bumps (CLI tools)
+  - Anything else (e.g. `renovate.json5` preset bumps like `aquaproj/aqua-renovate-config`, or `.github/workflows/*` action bumps) is **out of scope**: note it in the summary and skip (no upstream-diff review, no comment).
+- Only unreviewed PRs: skip any PR that already has a `<!-- review-renovate-pr -->` comment OR a label starting with `reviewed`, or a `wait` label
 - Optional PR number argument: `/review-renovate-pr 21` processes just that PR
 
 ## Required tools
 
 `gh` CLI with repo auth, `jq`. No git clone required — all diffs come from GitHub's compare API.
 
-Run all commands from `~/dotfiles` (the skill reads `renovate-lazy.json` via relative path):
+- **lazy** PRs resolve the upstream repo from `renovate-lazy.json` (relative path → run from `~/dotfiles`).
+- **aqua** PRs derive the upstream repo from the package name in the `aqua.yaml` hunk.
+
 ```bash
 cd ~/dotfiles
 ```
@@ -50,17 +56,25 @@ If the result is >= 1, skip that PR.
 
 If the remaining list is empty, tell the user "No unreviewed Renovate PRs." and stop.
 
-### 2. For each PR, extract the update
+### 2. Classify each PR and extract the update
 
 ```bash
 gh pr view <N> --json title,headRefName,baseRefName
-gh pr diff <N>
+gh pr diff <N> --name-only   # which files changed → classify
+gh pr diff <N>               # the hunks
 ```
+
+Classify by the changed file:
+- contains `lazy-lock.json` → **lazy** PR → step 2.1
+- contains `aqua.yaml` → **aqua** PR → step 2.2
+- neither → out of scope; record in summary as `SKIP (not a lazy/aqua PR)` and move on.
+
+#### 2.1 lazy PR extraction
 
 Parse the `lazy-lock.json` diff hunk to extract:
 - Plugin name (the JSON key, e.g. `telescope.nvim`)
-- Old commit SHA (on the `-` line)
-- New commit SHA (on the `+` line)
+- Old commit SHA (on the `-` line) → `OLD_REF`
+- New commit SHA (on the `+` line) → `NEW_REF`
 
 Look up the upstream repo URL by matching the plugin name against `renovate-lazy.json`:
 
@@ -70,26 +84,59 @@ jq -r --arg name "<plugin>" \
   renovate-lazy.json
 ```
 
-Strip `https://github.com/` to get `<owner>/<repo>`.
+Strip `https://github.com/` to get `<owner>/<repo>`. This PR type is **digest-tracking**, so the intermediate-SHA fallback (step 7) applies.
 
-### 3. Check commit age
+#### 2.2 aqua PR extraction
+
+Parse the `aqua.yaml` diff hunk:
+- `-  - name: <pkg>@<OLD_TAG>` → `OLD_REF=<OLD_TAG>`
+- `+  - name: <pkg>@<NEW_TAG>` → `NEW_REF=<NEW_TAG>`
+
+`<pkg>` is the aqua package name, e.g. `caddyserver/caddy`, `kubernetes/kubernetes/kubectl`, `jqlang/jq` (tags can be non-`v` prefixed, e.g. `jq-1.8.1`, `bun-v1.3.14`).
+
+Resolve the upstream GitHub repo: take the **first two path segments** of `<pkg>` as `<owner>/<repo>` (so `kubernetes/kubernetes/kubectl` → `kubernetes/kubernetes`). Confirm it exists by **exit code** — `gh api` prints the 404 error body to stdout, so don't test for empty output:
 
 ```bash
-committer_date=$(gh api repos/<owner>/<repo>/commits/<NEW_SHA> --jq '.commit.committer.date')
+if gh api repos/<owner>/<repo> >/dev/null 2>&1; then echo github; else echo non-github; fi
+```
+
+- If `non-github`, the package is **not GitHub-backed** (e.g. `1password/cli` is fetched over HTTP from a vendor CDN). Skip the upstream diff (step 4): record `upstream diff unavailable (non-GitHub datasource)`, recommend manual review against the vendor's release notes, and note that the `aqua-checksums.json` SHA256 is the real integrity control here. Still post a comment with the age result if obtainable, else mark the age check `n/a`.
+
+The compare refs are the **tags themselves**. `gh api repos/<owner>/<repo>/commits/<TAG>` resolves a tag to its commit (used for the age check), and `compare/<OLD_TAG>...<NEW_TAG>` works on tag names.
+
+This PR type is **tag-pinned**, so the intermediate-SHA fallback (step 7) does **not** apply (see step 7 scope).
+
+**Checksum-presence check (aqua only):** record whether the PR already regenerated the checksums.
+
+```bash
+gh pr diff <N> --name-only | grep -qx aqua-checksums.json && echo present || echo missing
+```
+
+PRs created after the `postUpgradeTasks`/`aqua upc` hook landed include `aqua-checksums.json` automatically (`present`). Older backlog PRs are `missing` and need `aqua upc -a --prune` run on the branch before merge, or `aqua install` fails (`require_checksum: true`). Surface this in the comment and summary; it does **not** by itself change the MERGE/REVIEW/DO-NOT-MERGE verdict.
+
+### 3. Check age
+
+Works for both PR types — `OLD_REF`/`NEW_REF` is a commit SHA (lazy) or a tag (aqua); `gh api .../commits/<ref>` resolves either.
+
+```bash
+committer_date=$(gh api repos/<owner>/<repo>/commits/<NEW_REF> --jq '.commit.committer.date')
 age_days=$(jq -n --arg d "$committer_date" '($d | fromdate) as $t | ((now - $t) / 86400) | floor')
 ```
 
 `jq fromdate` parses ISO 8601 portably (avoids BSD vs GNU `date` incompatibility). Threshold: **10 days**. Record PASS if `age_days >= 10`, else FAIL.
 
-**If FAIL (< 10 days): skip steps 4 and 5 for this PR.** Do not run the diff review on the tip SHA, do not post a comment. Then run the **Intermediate-SHA fallback** (step 7 below) to look for a reviewable intermediate commit. Record the age/WAIT state plus any fallback findings for the chat summary in step 6.
+**If FAIL (< 10 days): skip steps 4 and 5 for this PR.** Do not run the diff review, do not post a comment.
+- **lazy** PR → run the **Intermediate-SHA fallback** (step 7).
+- **aqua** PR → no fallback (step 7 scope); just record WAIT.
+
+Record the age/WAIT state (plus any fallback findings) for the chat summary in step 6.
 
 ### 4. Fetch and analyze the diff (age PASS only)
 
-Skip this step if age check in step 3 failed.
-
+Skip this step if age check in step 3 failed, or (aqua) if the package is non-GitHub-backed.
 
 ```bash
-gh api "repos/<owner>/<repo>/compare/<OLD_SHA>...<NEW_SHA>" \
+gh api "repos/<owner>/<repo>/compare/<OLD_REF>...<NEW_REF>" \
   --jq '{
     ahead: .ahead_by,
     commits: [.commits[] | {sha: .sha[0:7], author: .commit.author.name, date: .commit.author.date, message: (.commit.message | split("\n")[0])}],
@@ -99,32 +146,28 @@ gh api "repos/<owner>/<repo>/compare/<OLD_SHA>...<NEW_SHA>" \
 
 Inspect `/tmp/rr-<N>.json` carefully. Scan patches for:
 
-**HIGH severity (flag as DO NOT MERGE):**
+**HIGH severity (flag as DO NOT MERGE) — applies to both PR types:**
 - New `curl`, `wget`, `Invoke-WebRequest` piped into a shell (`| bash`, `| sh`, `| powershell`)
 - New `eval`, `loadstring`, `load()`, `assert(loadstring(...))`, `vim.fn.execute()`, `os.execute`, `io.popen`, `os.popen`, `vim.fn.system()` / `vim.fn.systemlist()` applied to anything that could be attacker-controlled (env vars parsed from web, remote fetches, user input)
 - Reads of credential-bearing paths: `~/.ssh`, `~/.aws`, `~/.config/gh`, `~/.netrc`, `.env`, `*_token*`, `*_key*`, `~/.bash_history`, `~/.zsh_history`
 - Large inline base64 / hex / long numeric blobs (>200 chars, suggestive of obfuscated payload)
-- New network endpoints (domains not obviously associated with the plugin's purpose)
-- Commit author identity changed to an unknown account (new commits by someone other than the plugin's usual maintainers — cross-check against `commits[].author`)
+- New network endpoints (domains not obviously associated with the project's purpose)
+- Commit author identity changed to an unknown account (new commits by someone other than the project's usual maintainers — cross-check against `commits[].author`)
 
 **MEDIUM severity (flag as REVIEW MANUALLY):**
-- Unexpectedly large addition of unrelated files (>20 new files in a non-refactor commit)
-- Binary file additions
-- New dependencies in plugin manifests (e.g., a Lua plugin suddenly pulling a native library)
-- Added `dependencies` entries to the plugin's own lazy.nvim spec
-- Significant non-lua/vim file additions (.py, .rs, .go, .sh where the plugin is pure vim)
+- _lazy_: Significant non-lua/vim file additions (`.py`, `.rs`, `.go`, `.sh` where the plugin is pure vim); added `dependencies` to the plugin's lazy.nvim spec; a Lua plugin suddenly pulling a native library
+- _aqua_: changes to the tool's **release/build pipeline or install scripts** (`.github/workflows/*release*`, `.goreleaser.*`, `install.sh`, publish-time `Dockerfile`s) — because aqua downloads the resulting release asset, a compromised release pipeline is the relevant supply-chain vector. (The binary content itself is still pinned by `aqua-checksums.json` SHA256, which is your backstop.) Do **NOT** flag normal source files in the tool's own language (`.go`/`.rs`/`.ts`/…) — unlike vim plugins, these tools are legitimately polyglot.
+- _both_: unexpectedly large addition of unrelated files (>20 new files in a non-refactor commit); binary file additions
 
-**LOW / clean:**
-- README / docs only
-- Syntax / type / doc-comment fixes
-- Test additions
-- Refactors touching existing files only
+**LOW / clean (both):** README/docs only; syntax/type/doc-comment fixes; test additions; refactors touching existing files only.
+
+**Diff too large:** mega-repos (e.g. `kubernetes/kubernetes`) produce compares with hundreds of commits / GitHub truncates at 250 commits & 300 files. If `ahead` is very large or the file list is obviously truncated, do not pretend to have scanned it: record `diff too large for automated scan` → **REVIEW MANUALLY**, and lean on the release notes + the `aqua-checksums.json` pin.
 
 ### 5. Post the review comment (age PASS only)
 
 Skip this step if age check in step 3 failed. Review comments are only posted once a PR has cleared the 10-day gate.
 
-Build the comment body using this template (include the HTML marker so we can detect our own comments in the future):
+Build the comment body using this template (include the HTML marker so we can detect our own comments in the future). Use **Package** for the row label in both cases; for lazy PRs the value is `<owner>/<repo>` (`<plugin>`), for aqua PRs it is `<owner>/<repo>` (`<pkg>`). `<OLD_DISP>`/`<NEW_DISP>` are the short SHAs (lazy) or the tags (aqua).
 
 ```markdown
 <!-- review-renovate-pr -->
@@ -132,12 +175,14 @@ Build the comment body using this template (include the HTML marker so we can de
 
 | Check | Result |
 |---|---|
-| Plugin | `<owner>/<repo>` (`<plugin>`) |
-| Update | `<OLD_SHORT>` → `<NEW_SHORT>` |
-| Commits ahead | <ahead_by> |
-| New commit age | <age> days — PASS |
+| Type | <lazy | aqua> |
+| Package | `<owner>/<repo>` (`<plugin-or-pkg>`) |
+| Update | `<OLD_DISP>` → `<NEW_DISP>` |
+| Commits ahead | <ahead_by | n/a> |
+| New <commit|tag> age | <age> days — PASS |
 | Files changed | <count> |
-| Diff review | <clean / N findings> |
+| Diff review | <clean / N findings / too large / unavailable> |
+| Checksum in PR | <yes | no — run `aqua upc -a --prune` before merge | n/a (lazy)> |
 
 ### Diff findings
 <itemized findings with file:line references, or "No red flags detected.">
@@ -151,6 +196,8 @@ Build the comment body using this template (include the HTML marker so we can de
 *Generated by `review-renovate-pr` skill.*
 ```
 
+For an **aqua** PR where `Checksum in PR` is `no`, append to the reason: "merge requires regenerating `aqua-checksums.json` first (`aqua upc -a --prune` on the branch, commit, then merge)."
+
 Post automatically:
 
 ```bash
@@ -162,45 +209,45 @@ EOF
 
 ### 6. Chat summary
 
-After processing all PRs, print one compact block:
+After processing all PRs, print one compact block. Show the type and (for aqua) the checksum state.
 
 ```
 Processed N Renovate PR(s):
 
-#<N> <plugin> (<old7>..<new7>)
+#<N> [lazy] <plugin> (<old7>..<new7>)
   Age: <X>d ✓  Diff: <clean|N flags>  → <MERGE OK|REVIEW|DO NOT MERGE>  (comment posted)
 
-#<N> <plugin> (<old7>..<new7>)
-  Age: <X>d ✗  → WAIT (comment skipped)
-  Intermediate: (none ≥ threshold in <total> commits)
+#<N> [aqua] <pkg> (<OLD_TAG> → <NEW_TAG>)
+  Age: <X>d ✓  Diff: <clean|N flags|too large>  Checksum: <in-PR|MISSING>  → <verdict>  (comment posted)
 
-#<N> <plugin> (<old7>..<new7>)
+#<N> [lazy] <plugin> (<old7>..<new7>)
   Age: <X>d ✗  → WAIT (comment skipped)
   Intermediate <int7> (<Y>d, <ahead> commits): clean → APPLIABLE
 
-#<N> <plugin> (<old7>..<new7>)
-  Age: <X>d ✗  → WAIT (comment skipped)
-  Intermediate <int7> (<Y>d, <ahead> commits): <N> flags → DO NOT APPLY
+#<N> [aqua] <pkg> (<OLD_TAG> → <NEW_TAG>)
+  Age: <X>d ✗  → WAIT (comment skipped; tag-pinned, no intermediate)
+
+#<N> [skip] <branch> — not a lazy/aqua PR
 
 ...
 ```
 
-(`<new7>` = the PR's tip SHA, i.e. the value on the `+` line of the lazy-lock.json diff hunk; `<int7>` = the chosen intermediate SHA from step 7.1.)
+(`<new7>` = the lazy PR's tip SHA, i.e. the value on the `+` line of the lazy-lock.json diff hunk; `<int7>` = the chosen intermediate SHA from step 7.1.)
 
-Do NOT merge any PR. Do NOT edit `lazy-lock.json` or close any PR. The skill's job ends at the comment + summary + (for fallback) presenting the appliable candidate to the user.
+Do NOT merge any PR. Do NOT edit `lazy-lock.json` / `aqua.yaml` / `aqua-checksums.json` or close any PR. The skill's job ends at the comment + summary + (for the lazy fallback) presenting the appliable candidate to the user.
 
-### 7. Intermediate-SHA fallback (age FAIL only)
+### 7. Intermediate-SHA fallback (lazy, age FAIL only)
 
-When step 3 reports FAIL, the PR's tip SHA is too recent — but an *earlier* commit in the same compare range may already satisfy the age threshold from step 3. In active repos (e.g. nvim-lspconfig, vimdoc-ja), waiting for the tip to age out is a moving target because Renovate force-pushes the PR to the latest HEAD on each weekly run. The fallback finds the newest intermediate commit that has aged out, runs the same red-flag diff review against `OLD_SHA..INTERMEDIATE_SHA`, and surfaces it as a candidate for hand-pinning.
+When step 3 reports FAIL for a **lazy** PR, the tip SHA is too recent — but an *earlier* commit in the same compare range may already satisfy the threshold. In active repos (e.g. nvim-lspconfig, vimdoc-ja), waiting for the tip to age out is a moving target because Renovate force-pushes the PR to the latest HEAD on each weekly run. The fallback finds the newest intermediate commit that has aged out, runs the same red-flag diff review against `OLD_REF..INTERMEDIATE_SHA`, and surfaces it as a hand-pin candidate.
 
-**Scope**: only run for digest-tracking PRs (`lazy-lock.json` `branch + commit` pins). Tag-pinned updates (e.g. `aqua.yaml` `bun-v1.3.13`) have no concept of "intermediate" — skip the fallback there.
+**Scope**: only digest-tracking **lazy** PRs. **aqua** tag-pinned PRs have no arbitrary-commit pin — aqua pins tags, not SHAs — so on age FAIL just report WAIT (no fallback). (Optional: if an intermediate *tag* in the range has aged out — e.g. old `v0.30.0` → new `v0.32.0` with `v0.31.0` ≥10d old — you MAY surface that intermediate tag as a hand-pin candidate, but do not auto-apply.)
 
 #### 7.1 Find the newest qualifying intermediate commit
 
 GitHub's compare API lists commits oldest-first. Iterate from newest backward; the first commit whose age clears the step 3 threshold (currently 10 days — keep the `-ge 10` literal below in sync if step 3 changes) wins:
 
 ```bash
-gh api "repos/<owner>/<repo>/compare/<OLD_SHA>...<NEW_SHA>" \
+gh api "repos/<owner>/<repo>/compare/<OLD_REF>...<NEW_REF>" \
   --jq '[.commits[] | "\(.commit.committer.date)\t\(.sha)"] | reverse | .[]' \
 | while IFS=$'\t' read -r d sha; do
     age=$(jq -n --arg d "$d" '($d|fromdate) as $t | ((now - $t)/86400) | floor')
@@ -212,10 +259,10 @@ If the loop produces no output, no qualifying intermediate exists — record the
 
 #### 7.2 Diff-review the intermediate range
 
-Run the **same** patch-scan as step 4, but against `OLD_SHA..INTERMEDIATE_SHA`. Use the same jq spec as step 4 so the on-disk shape matches and the same red-flag heuristics apply:
+Run the **same** patch-scan as step 4, but against `OLD_REF..INTERMEDIATE_SHA`. Use the same jq spec as step 4 so the on-disk shape matches and the same red-flag heuristics apply:
 
 ```bash
-gh api "repos/<owner>/<repo>/compare/<OLD_SHA>...<INTERMEDIATE_SHA>" \
+gh api "repos/<owner>/<repo>/compare/<OLD_REF>...<INTERMEDIATE_SHA>" \
   --jq '{
     ahead: .ahead_by,
     commits: [.commits[] | {sha: .sha[0:7], author: .commit.author.name, date: .commit.author.date, message: (.commit.message | split("\n")[0])}],
@@ -244,14 +291,19 @@ The `wait` label is honored by step 1's PR enumeration filter, so subsequent inv
 
 ## Recommendation table
 
-| Age check (tip) | Intermediate fallback | Diff review | Action |
-|---|---|---|---|
-| PASS (>=10d) | — | clean | Comment posted → MERGE OK |
-| PASS | — | MEDIUM flags | Comment posted → REVIEW MANUALLY |
-| PASS | — | HIGH flags | Comment posted → DO NOT MERGE |
-| FAIL (<10d) | none qualifies | (not performed) | No comment. Chat summary reports WAIT. |
-| FAIL | intermediate found | clean | No comment. Chat surfaces APPLIABLE intermediate + opt-in commands; user authorizes. |
-| FAIL | intermediate found | MEDIUM/HIGH flags | No comment. Chat surfaces DO NOT APPLY; WAIT. |
+| PR type | Age check (tip/new tag) | Intermediate fallback | Diff review | Action |
+|---|---|---|---|---|
+| lazy | PASS (>=10d) | — | clean | Comment posted → MERGE OK |
+| lazy | PASS | — | MEDIUM flags | Comment posted → REVIEW MANUALLY |
+| lazy | PASS | — | HIGH flags | Comment posted → DO NOT MERGE |
+| lazy | FAIL (<10d) | none qualifies | (not performed) | No comment. Chat summary reports WAIT. |
+| lazy | FAIL | intermediate found | clean | No comment. Chat surfaces APPLIABLE intermediate + opt-in commands; user authorizes. |
+| lazy | FAIL | intermediate found | MEDIUM/HIGH flags | No comment. Chat surfaces DO NOT APPLY; WAIT. |
+| aqua | PASS | n/a | clean (checksum in-PR) | Comment posted → MERGE OK |
+| aqua | PASS | n/a | clean (checksum MISSING) | Comment posted → MERGE OK *after* `aqua upc -a --prune` on the branch |
+| aqua | PASS | n/a | MEDIUM/HIGH or too large | Comment posted → REVIEW MANUALLY / DO NOT MERGE |
+| aqua | PASS | n/a | unavailable (non-GitHub) | Comment posted → REVIEW MANUALLY against vendor release notes; checksum pin is the control |
+| aqua | FAIL | n/a (tag-pinned) | (not performed) | No comment. Chat reports WAIT. |
 
 ## Force re-review
 
@@ -263,6 +315,10 @@ To re-review a PR that was already reviewed or suppressed:
 ## Failure modes
 
 - If `gh pr diff` returns an empty diff: the PR may be in an odd state — note in summary, skip review comment, skip.
-- If the upstream repo cannot be resolved from `renovate-lazy.json`: skip with a chat note; don't guess.
-- If `gh api compare` 404s (commit unavailable or force-pushed): report as "upstream diff unavailable" and recommend manual review.
+- (lazy) If the upstream repo cannot be resolved from `renovate-lazy.json`: skip with a chat note; don't guess.
+- (aqua) If the package is not GitHub-backed (`gh api repos/<owner>/<repo>` 404s — e.g. `1password/cli`): skip the upstream diff, recommend manual review against the vendor's release notes, and note the `aqua-checksums.json` SHA256 is the integrity control. Still post a comment with the age result.
+- (aqua) Path-style package names (`owner/repo/subpath`, e.g. `kubernetes/kubernetes/kubectl`): the repo is the first two segments.
+- (aqua) Mega-repo / truncated compare: record `diff too large for automated scan` → REVIEW MANUALLY.
+- (aqua) `aqua-checksums.json` missing from the PR is **not** a red flag — it just means the bump predates the `aqua upc` postUpgrade hook; flag that `aqua upc -a --prune` must run before merge.
+- If `gh api compare` 404s (commit/tag unavailable or force-pushed): report as "upstream diff unavailable" and recommend manual review.
 - Rate limit (403 with `x-ratelimit-remaining: 0`): stop processing, report remaining PRs as skipped.

--- a/.claude/skills/review-renovate-pr/SKILL.md
+++ b/.claude/skills/review-renovate-pr/SKILL.md
@@ -64,10 +64,10 @@ gh pr diff <N> --name-only   # which files changed → classify
 gh pr diff <N>               # the hunks
 ```
 
-Classify by the changed file:
+Classify by the changed file **and** hunk shape:
 - contains `lazy-lock.json` → **lazy** PR → step 2.1
-- contains `aqua.yaml` → **aqua** PR → step 2.2
-- neither → out of scope; record in summary as `SKIP (not a lazy/aqua PR)` and move on.
+- contains `aqua.yaml` **and** the diff includes a `- name: <pkg>@<tag>` package-entry change → **aqua** PR → step 2.2
+- anything else → out of scope; record in summary as `SKIP (not a lazy/aqua PR)` and move on. Note in particular that `aqua.yaml` also holds the `registries[].ref` pin (aqua-registry version): a PR that only bumps that line touches `aqua.yaml` but has **no** `- name: …@…` hunk, so it is out of scope here — don't try to force it through step 2.2.
 
 #### 2.1 lazy PR extraction
 
@@ -116,11 +116,20 @@ PRs created after the `postUpgradeTasks`/`aqua upc` hook landed include `aqua-ch
 
 ### 3. Check age
 
-Works for both PR types — `OLD_REF`/`NEW_REF` is a commit SHA (lazy) or a tag (aqua); `gh api .../commits/<ref>` resolves either.
+The gate mirrors Renovate's `minimumReleaseAge`, which measures **how long ago the artifact was published** — so the date source differs by PR type:
+
+- **lazy** (digest pin): the new ref *is* the commit, so commit date = release date.
+  ```bash
+  ref_date=$(gh api repos/<owner>/<repo>/commits/<NEW_REF> --jq '.commit.committer.date')
+  ```
+- **aqua** (tag pin): use the **tag/release publish date**, not the underlying commit date. A tag cut today on top of an old commit is a 0-day-old release even though its commit is old — using commit date would wrongly PASS it. Prefer the GitHub Release `published_at`; fall back to the tag's commit date only when there is no Release (lightweight/annotated tag, which is what Renovate's `github-tags` datasource also falls back to):
+  ```bash
+  ref_date=$(gh api "repos/<owner>/<repo>/releases/tags/<NEW_REF>" --jq '.published_at' 2>/dev/null)
+  [ -z "$ref_date" ] && ref_date=$(gh api "repos/<owner>/<repo>/commits/<NEW_REF>" --jq '.commit.committer.date')
+  ```
 
 ```bash
-committer_date=$(gh api repos/<owner>/<repo>/commits/<NEW_REF> --jq '.commit.committer.date')
-age_days=$(jq -n --arg d "$committer_date" '($d | fromdate) as $t | ((now - $t) / 86400) | floor')
+age_days=$(jq -n --arg d "$ref_date" '($d | fromdate) as $t | ((now - $t) / 86400) | floor')
 ```
 
 `jq fromdate` parses ISO 8601 portably (avoids BSD vs GNU `date` incompatibility). Threshold: **10 days**. Record PASS if `age_days >= 10`, else FAIL.
@@ -133,7 +142,9 @@ Record the age/WAIT state (plus any fallback findings) for the chat summary in s
 
 ### 4. Fetch and analyze the diff (age PASS only)
 
-Skip this step if age check in step 3 failed, or (aqua) if the package is non-GitHub-backed.
+Skip this step if age check in step 3 failed, or (aqua) if the package's **source** is not on GitHub.
+
+**What the aqua source diff does and does not cover:** a GitHub repo existing for the package only means its *source* is reviewable — it does **not** mean aqua downloads the *binary* from GitHub. Several packages here ship their artifact from a vendor host (e.g. `helm/helm` → `get.helm.sh`, `kubernetes/kubernetes/kubectl` → `dl.k8s.io`) while their source lives on GitHub. The source compare below is therefore **supplementary** (it surfaces suspicious source-side changes); it never proves the distributed binary is safe. The artifact-integrity control is **always** the `aqua-checksums.json` SHA256 pin, regardless of which host aqua fetches from. So a clean source scan → `MERGE OK` still rests on the checksum being present/regenerated, never on the scan alone. When you know the artifact is distributed off-GitHub, say so in the comment (`source reviewed; binary integrity rests on the checksum pin`).
 
 ```bash
 gh api "repos/<owner>/<repo>/compare/<OLD_REF>...<NEW_REF>" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Step 2 is **mandatory for manual edits**: CI only regenerates `aqua-checksums.js
 
 `aqua-renovate-config` can't update `aqua-checksums.json`, so `renovate.json5` adds a `postUpgradeTasks` hook that runs `aqua upc -a --prune` on any branch touching `aqua.yaml`, committing the regenerated checksums into the same Renovate PR. This is why `.github/workflows/renovate.yml` runs Renovate via `npx` (not the container action) with `aqua` on `PATH`, and allow-lists exactly that one command via `RENOVATE_ALLOWED_COMMANDS`. It covers **Renovate PRs only** — manual `aqua.yaml` edits still need step 2 above. (There is intentionally no `on: pull_request` checksum workflow: it can't auto-run on bot-authored PRs because GitHub gates `github-actions[bot]` PR workflows as `action_required`.)
 
-`minimumReleaseAge: "10 days"` (set globally) applies to aqua PRs as well, matching the lazy-lock.json policy. The `/review-renovate-pr` skill should be extended to cover `aqua.yaml` PRs in the same style as the lazy plugin reviews.
+`minimumReleaseAge: "10 days"` (set globally) applies to aqua PRs as well, matching the lazy-lock.json policy. The `/review-renovate-pr` skill covers `aqua.yaml` tag PRs in the same style as the lazy plugin reviews (age gate + upstream-diff red-flag scan against the old→new tag, plus a check that the PR carries the regenerated `aqua-checksums.json`).
 
 ### Bumping aqua itself
 
@@ -119,7 +119,7 @@ Plugin updates in this repo do **not** come from `:Lazy update` → commit. They
 
 ## Reviewing Renovate PRs
 
-The `/review-renovate-pr` skill (defined in `.claude/skills/review-renovate-pr/SKILL.md`) handles triage of open Renovate PRs: it enforces the 10-day age gate, scans upstream diffs for supply-chain red flags, and posts a review comment per PR. Use it instead of reviewing Renovate PRs by hand. It must be run from `~/dotfiles` because it reads `renovate-lazy.json` via a relative path.
+The `/review-renovate-pr` skill (defined in `.claude/skills/review-renovate-pr/SKILL.md`) handles triage of open Renovate PRs of both kinds — `lazy-lock.json` plugin digest bumps and `aqua.yaml` CLI tool tag bumps. It enforces the 10-day age gate, scans the upstream diff (commit range for lazy, old→new tag for aqua) for supply-chain red flags, flags aqua PRs that lack the regenerated `aqua-checksums.json`, and posts a review comment per PR. Preset/action bumps (`renovate.json5`, `.github/workflows/*`) are out of scope and skipped. Use it instead of reviewing Renovate PRs by hand. It must be run from `~/dotfiles` because it reads `renovate-lazy.json` via a relative path.
 
 ## Reviewing Homebrew updates
 


### PR DESCRIPTION
## Why

`/review-renovate-pr` only triaged `lazy-lock.json` digest PRs; aqua `aqua.yaml` tag-bump PRs were out of coverage (a TODO noted in CLAUDE.md). With the aqua backlog now flowing through Renovate, extend the skill to review those too.

## What

- **Classify** each `renovate/*` PR by changed file: `lazy` (lazy-lock.json) / `aqua` (aqua.yaml) / out-of-scope (preset/action bumps → skipped).
- **aqua extraction**: parse the `name: <pkg>@<tag>` hunk; derive the upstream repo from the first two path segments (handles `owner/repo/subpath` like `kubernetes/kubernetes/kubectl`); the compare refs are the tags themselves.
- **Shared age gate** (10d) and **diff red-flag scan**, reused for both types. aqua adjustments: don't flag normal polyglot tool source (`.go`/`.rs`/…), but **do** flag release-pipeline / install-script changes (the supply-chain vector, since aqua pulls the release asset); mega-repo / truncated compares → REVIEW MANUALLY.
- **Non-GitHub packages** (e.g. `1password/cli`, http datasource) detected by `gh api` exit code → manual review against vendor release notes; the `aqua-checksums.json` SHA256 is the integrity control.
- **Checksum-presence check**: flag aqua PRs missing the regenerated `aqua-checksums.json` (backlog PRs predating the `aqua upc` postUpgrade hook) — merge needs `aqua upc -a --prune` first.

Recommendation table and failure modes extended with aqua rows. CLAUDE.md updated to mark the extension done.

## Validation

Dry-ran the new aqua logic (no comments posted) against representative open PRs:
- `#62 helm/helm v4.1.4→v4.2.0` — repo OK, tag age 43d, ahead_by 306 → "diff too large → REVIEW MANUALLY", checksum MISSING.
- `#67 kubernetes-sigs/kind v0.31.0→v0.32.0` — repo OK, age 16d, checksum in-PR.
- `#64 1password/cli` — `non-github` correctly detected by exit code → manual-review path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
