### PR TITLE
chore(deps): pin nvim-lspconfig, vimdoc-ja to reviewed intermediate SHAs

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -10,7 +10,7 @@
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-highlight-colors": { "branch": "main", "commit": "e4c7af0211866162d999ce0bdd6a029302e19139" },
-  "nvim-lspconfig": { "branch": "master", "commit": "9573948c38bfabeec353ae7dd7d3ffec4c506a6b" },
+  "nvim-lspconfig": { "branch": "master", "commit": "ed19590a3a9792901553c388d1aadafce012f80d" },
   "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
   "nvim-treesitter-context": { "branch": "master", "commit": "b311b30818951d01f7b4bf650521b868b3fece16" },
   "nvim-ts-autotag": { "branch": "main", "commit": "88c1453db4ba7dd24131086fe51fdf74e587d275" },
@@ -27,5 +27,5 @@
   "vim-fugitive": { "branch": "master", "commit": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0" },
   "vim-rails": { "branch": "master", "commit": "b0a5c76f86ea214ade36ab0b811e730c3f0add67" },
   "vim-ruby": { "branch": "master", "commit": "bf3a5994ce63796db7b1b04aea92772271f387aa" },
-  "vimdoc-ja": { "branch": "master", "commit": "f0ac8f17699388ab439c581be34517bde1b72df2" }
+  "vimdoc-ja": { "branch": "master", "commit": "7ad16f3f380b1eecbc0219bc6215283183681987" }
 }


### PR DESCRIPTION
Renovate PRs #45 (nvim-lspconfig) and #47 (vimdoc-ja) tracked tip SHAs only 0 days old — these repos move daily so the tip never clears the 10-day gate before Renovate force-pushes a newer one. Pin to the newest reviewed intermediate commit per `/review-renovate-pr`:

| Plugin | Old | New (intermediate) | Age | Range |
|---|---|---|---|---|
| nvim-lspconfig | `9573948` | `ed19590` | 10d | lsp/ config additions, type defs, docs — clean |
| vimdoc-ja | `f0ac8f1` | `7ad16f3` | 10d | doc/*.jax JP translations only — clean |

Both intermediate ranges reviewed clean (no remote-exec/credential/obfuscation). Supersedes #45 and #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)